### PR TITLE
FIX: ensure slash in ImageURL for session ImageURL

### DIFF
--- a/savePersonDetails.go
+++ b/savePersonDetails.go
@@ -19,6 +19,7 @@ import (
 	"phonebook/sess"
 	"strconv"
 	"strings"
+	"phonebook/ui"
 )
 
 func uploadFileCopy(from *multipart.File, toname string) error {
@@ -104,7 +105,8 @@ func uploadImageFileToS3(fileHeader *multipart.FileHeader, usrfile multipart.Fil
 	}
 
 	// get image location
-	imageLocation := path.Join(lib.AppConfig.S3BucketHost, lib.AppConfig.S3BucketName, imagePath)
+	//imageLocation := path.Join(lib.AppConfig.S3BucketHost, lib.AppConfig.S3BucketName, imagePath)
+	imageLocation := ui.GenerateImageLocation(imagePath)
 
 	ulog("Response of Image Uploading: \n%s\n", awsutil.StringValue(resp))
 	ulog("Image location: %s", imageLocation)

--- a/sess/session.go
+++ b/sess/session.go
@@ -199,7 +199,6 @@ func pvtNewSession(c *db.SessionCookie, firstname string, rid int, updateSession
 	s.Firstname = firstname
 	s.UID = c.UID
 	s.UIDorig = c.UID
-	//s.ImageURL = ui.GetImageFilename(uid)
 	s.ImageURL = ui.GetImageLocation(uid)
 	s.Breadcrumbs = make([]ui.Crumb, 0)
 	s.Expire = c.Expire

--- a/test/usersim/loadUsers.go
+++ b/test/usersim/loadUsers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"phonebook/ui"
 )
 
 func getCompanyInfo(cocode int, c *company) {
@@ -89,7 +90,8 @@ func getImageFilename(uid int) string {
 //  returns 0 if success, err number otherwise
 //===========================================================
 func getPersonDetail(d *personDetail, uid int) int {
-	d.Image = getImageFilename(uid)
+	//d.Image = getImageFilename(uid)
+	d.Image = ui.GetImageLocation(uid)
 	err := App.db.QueryRow("select lastname,firstname,preferredname,jobcode,primaryemail,"+
 		"officephone,cellphone,deptcode,cocode,mgruid,ClassCode,"+
 		"HomeStreetAddress,HomeStreetAddress2,HomeCity,HomeState,HomePostalCode,HomeCountry "+

--- a/ui/image.go
+++ b/ui/image.go
@@ -2,25 +2,32 @@ package ui
 
 import (
 	"net/url"
+	"path"
 	"phonebook/db"
 	"phonebook/lib"
 )
 
 // GetImageLocation returns the ImageURL for the specified user.
 func GetImageLocation(uid int) string {
-	lib.Console("Entered GetImageLocation\n")
 	var imagePath string
 
 	defaultImageName := "defaultProfileImage.png"
+
+	im := defaultImageName // If something went wrong  or database doesn't have imagePath than display default image
+	err := db.PrepStmts.GetImagePath.QueryRow(uid).Scan(&imagePath)
+	if imagePath != "" && err == nil {
+		im = imagePath
+	}
+	return GenerateImageLocation(im)
+}
+
+// GenerateImageLocation return the image URL from the image path
+func GenerateImageLocation(imagePath string) string {
 	u, err := url.Parse(lib.AppConfig.S3BucketHost)
 	if err != nil {
 		lib.Ulog("Error parsing: %s : %s\n", lib.AppConfig.S3BucketHost, err.Error())
 	}
-	pic := defaultImageName
-	err = db.PrepStmts.GetImagePath.QueryRow(uid).Scan(&imagePath)
-	if err == nil && imagePath != "" {
-		pic = imagePath
-	}
-	im := u.String() + "/" + lib.AppConfig.S3BucketName + "/" + pic
-	return im
+	u.Path = path.Join(u.Path, lib.AppConfig.S3BucketName, imagePath)
+	return u.String()
 }
+


### PR DESCRIPTION
It ensures double slash in session's imageURL when user change image.